### PR TITLE
add flag to force auth, and override env

### DIFF
--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -22,6 +22,7 @@ type Config interface {
 	CheckWriteable(string, string) error
 	Write() error
 	WriteHosts() error
+	OverrideEnv() bool
 }
 
 type ConfigOption struct {
@@ -210,6 +211,15 @@ func NewBlankRoot() *yaml.Node {
 					{
 						Kind:  yaml.ScalarNode,
 						Value: "",
+					},
+					{
+						HeadComment: "If ENV should be overriden for hosts.yml.",
+						Kind:        yaml.ScalarNode,
+						Value:       "override_env",
+					},
+					{
+						Kind:  yaml.ScalarNode,
+						Value: "false",
 					},
 				},
 			},

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -22,7 +22,7 @@ type Config interface {
 	CheckWriteable(string, string) error
 	Write() error
 	WriteHosts() error
-	OverrideEnv() bool
+	OverrideEnv(string) bool
 }
 
 type ConfigOption struct {

--- a/internal/config/from_env.go
+++ b/internal/config/from_env.go
@@ -75,7 +75,7 @@ func (c *envConfig) DefaultHostWithSource() (string, string, error) {
 		return host, GH_HOST, nil
 	}
 
-	return "", "", nil
+	return c.Config.DefaultHostWithSource()
 }
 
 func (c *envConfig) Get(hostname, key string) (string, error) {
@@ -94,7 +94,7 @@ func (c *envConfig) GetWithSource(hostname, key string) (string, string, error) 
 		}
 	}
 
-	return "", "", nil
+	return c.Config.GetWithSource(hostname, key)
 }
 
 func (c *envConfig) GetOrDefault(hostname, key string) (val string, err error) {
@@ -126,7 +126,7 @@ func (c *envConfig) CheckWriteable(hostname, key string) error {
 		}
 	}
 
-	return nil
+	return c.Config.CheckWriteable(hostname, key)
 }
 
 func AuthTokenFromEnv(hostname string) (string, string) {

--- a/internal/config/from_env.go
+++ b/internal/config/from_env.go
@@ -67,10 +67,6 @@ func (c *envConfig) DefaultHost() (string, error) {
 }
 
 func (c *envConfig) DefaultHostWithSource() (string, string, error) {
-	if c.Config.OverrideEnv() {
-		return c.Config.DefaultHostWithSource()
-	}
-
 	if host := os.Getenv(GH_HOST); host != "" {
 		return host, GH_HOST, nil
 	}
@@ -84,7 +80,7 @@ func (c *envConfig) Get(hostname, key string) (string, error) {
 }
 
 func (c *envConfig) GetWithSource(hostname, key string) (string, string, error) {
-	if c.Config.OverrideEnv() {
+	if c.Config.OverrideEnv(hostname) {
 		return c.Config.GetWithSource(hostname, key)
 	}
 
@@ -116,7 +112,7 @@ func (c *envConfig) Default(key string) string {
 }
 
 func (c *envConfig) CheckWriteable(hostname, key string) error {
-	if c.Config.OverrideEnv() {
+	if c.Config.OverrideEnv(hostname) {
 		return c.Config.CheckWriteable(hostname, key)
 	}
 

--- a/internal/config/from_env.go
+++ b/internal/config/from_env.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -68,17 +67,15 @@ func (c *envConfig) DefaultHost() (string, error) {
 }
 
 func (c *envConfig) DefaultHostWithSource() (string, string, error) {
-	var err error
-
-	if _, err = ReadConfigFile(HostsConfigFile()); err == nil {
+	if c.Config.OverrideEnv() {
 		return c.Config.DefaultHostWithSource()
 	}
 
-	if host := os.Getenv(GH_HOST); host != "" && errors.Is(err, os.ErrNotExist) {
+	if host := os.Getenv(GH_HOST); host != "" {
 		return host, GH_HOST, nil
 	}
 
-	return "", "", err
+	return "", "", nil
 }
 
 func (c *envConfig) Get(hostname, key string) (string, error) {
@@ -87,19 +84,17 @@ func (c *envConfig) Get(hostname, key string) (string, error) {
 }
 
 func (c *envConfig) GetWithSource(hostname, key string) (string, string, error) {
-	var err error
-
-	if _, err = ReadConfigFile(HostsConfigFile()); err == nil {
+	if c.Config.OverrideEnv() {
 		return c.Config.GetWithSource(hostname, key)
 	}
 
-	if hostname != "" && key == "oauth_token" && errors.Is(err, os.ErrNotExist) {
+	if hostname != "" && key == "oauth_token" {
 		if token, env := AuthTokenFromEnv(hostname); token != "" {
 			return token, env, nil
 		}
 	}
 
-	return "", "", err
+	return "", "", nil
 }
 
 func (c *envConfig) GetOrDefault(hostname, key string) (val string, err error) {
@@ -121,19 +116,17 @@ func (c *envConfig) Default(key string) string {
 }
 
 func (c *envConfig) CheckWriteable(hostname, key string) error {
-	var err error
-
-	if _, err = ReadConfigFile(HostsConfigFile()); err == nil {
+	if c.Config.OverrideEnv() {
 		return c.Config.CheckWriteable(hostname, key)
 	}
 
-	if hostname != "" && key == "oauth_token" && errors.Is(err, os.ErrNotExist) {
+	if hostname != "" && key == "oauth_token" {
 		if token, env := AuthTokenFromEnv(hostname); token != "" {
 			return &ReadOnlyEnvError{Variable: env}
 		}
 	}
 
-	return err
+	return nil
 }
 
 func AuthTokenFromEnv(hostname string) (string, string) {

--- a/internal/config/from_file.go
+++ b/internal/config/from_file.go
@@ -114,10 +114,10 @@ func (c *fileConfig) UnsetHost(hostname string) {
 	cm.RemoveEntry(hostname)
 }
 
-func (c *fileConfig) OverrideEnv() bool {
-	ent, _ := c.FindEntry("override_env")
+func (c *fileConfig) OverrideEnv(hostname string) bool {
+	overrideEnv, _ := c.Get(hostname, "override_env")
 
-	if ent.ValueNode.Value == "true" {
+	if overrideEnv == "true" {
 		return true
 	}
 

--- a/internal/config/from_file.go
+++ b/internal/config/from_file.go
@@ -114,6 +114,16 @@ func (c *fileConfig) UnsetHost(hostname string) {
 	cm.RemoveEntry(hostname)
 }
 
+func (c *fileConfig) OverrideEnv() bool {
+	ent, _ := c.FindEntry("override_env")
+
+	if ent.ValueNode.Value == "true" {
+		return true
+	}
+
+	return false
+}
+
 func (c *fileConfig) configForHost(hostname string) (*HostConfig, error) {
 	hosts, err := c.hostEntries()
 	if err != nil {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -138,7 +138,14 @@ func loginRun(opts *LoginOptions) error {
 		}
 	}
 
-	if !opts.ForceAuth {
+	if opts.ForceAuth {
+		err := cfg.Set(hostname, "override_env", "true")
+		if err != nil {
+			fmt.Printf("got error: %+v when attempting to set override_env", err)
+		}
+	}
+
+	if !opts.ForceAuth && !cfg.OverrideEnv(hostname) {
 		if err := cfg.CheckWriteable(hostname, "oauth_token"); err != nil {
 			var roErr *config.ReadOnlyEnvError
 			if errors.As(err, &roErr) {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -141,7 +141,7 @@ func loginRun(opts *LoginOptions) error {
 	if opts.ForceAuth {
 		err := cfg.Set(hostname, "override_env", "true")
 		if err != nil {
-			fmt.Printf("got error: %+v when attempting to set override_env", err)
+			fmt.Fprintf(opts.IO.ErrOut, "Failed to set `override_env` for host %s in %s, please set it your self.", hostname, config.ConfigFile())
 		}
 	}
 


### PR DESCRIPTION
- if there exists a /path/to/config/hosts.yml use that instead of
  env

TODO
- have new flag set a var in /path/to/config/config.yml that
  drives overriding env, instead of defacto overriding env

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
